### PR TITLE
update contributing

### DIFF
--- a/contributing/contributing.html
+++ b/contributing/contributing.html
@@ -22,6 +22,7 @@ These are the high-level notebook submission policies. More comprehensive guidel
 <h2>Foundations</h2>
 <p>Notebook code cells must be written in Python. Notebooks must use the kernel name python3. Version support is detailed in the <a href="https://github.com/spacetelescope/style-guides/blob/master/guides/software-versioning.md">Version Support Guide</a>.
 Notebook documentation cells are written in Markdown.<br>
+<p>Do NOT commit executed Notebooks. This needlessly inflates the size of our repositories and is a bit of a nightmare to handle.</p>
 
 <h3>Files and directories</h3>
 All notebooks must be in a sub-directory of the main notebooks directory. The directory name and the names of the files contained within it cannot contain whitespace or non-printable characters. (Underscores should be used in lieu of a space)<br><br>


### PR DESCRIPTION
Editing contributing to make clear people should NOT commit executed cells
- [ ] Need to update the section on pep8 compliance. As written, the code does not work. We can force a prior version with pip install flake8==3.9.2, but I'd rather choose a tool that is actively maintained