### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

[:ghost:](https://github.com/pllim/playpen/issues/63)